### PR TITLE
Feature/before after suite hooks

### DIFF
--- a/spec/features/edit_collection_spec.rb
+++ b/spec/features/edit_collection_spec.rb
@@ -4,7 +4,6 @@ feature "Editing collections" do
   before :all do 
     @root = FactoryGirl.create(:root_collection)
     @collection = FactoryGirl.create(:valid_owned_by_bill)
-    # @minimal_collection = FactoryGirl.create(:minimal_valid_collection)
     @user = FactoryGirl.create(:bill) 
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,9 +40,25 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
+  # Cleans everything.  Should figure out how to get Fedora to do this 
+  # automatically. 
+  config.before(:suite) do 
+    GenericFile.find(:all).each do |file| 
+      file.destroy 
+    end
+
+    NuCollection.find(:all).each do |collection| 
+      collection.destroy 
+    end
+
+    User.all.each do |user| 
+      user.destroy 
+    end
+  end
+
   # Clean everything.  Should figure out how to get Fedora to do this
   # automatically. 
-  after(:suite) do 
+  config.after(:suite) do 
     GenericFile.find(:all).each do |file| 
       file.destroy 
     end


### PR DESCRIPTION
The before(:suite) and after(:suite) hooks are executed before and after all tests run.  I wrote these as a general safety measure, because the Fedora repo doesn't appear to rollback to a clean state automatically between runs.  Note that a more elegant solution almost certainly exists, and that this doesn't remove the need to delete created Fedora objects after each spec runs.  
