### PR TITLE
Only depositors may now delete collections/core records.

### DIFF
--- a/app/controllers/nu_collections_controller.rb
+++ b/app/controllers/nu_collections_controller.rb
@@ -4,7 +4,8 @@ class NuCollectionsController < SetsController
   before_filter :authenticate_user!, only: [:new, :edit, :create, :update, :destroy ]
 
   before_filter :can_read?, only: [:show]
-  before_filter :can_edit?, only: [:edit, :update, :destroy]
+  before_filter :can_edit?, only: [:edit, :update]
+  before_filter :is_depositor?, only: [:destroy] 
 
   before_filter :can_edit_parent?, only: [:new, :create]
   before_filter :parent_is_personal_folder?, only: [:new, :create]

--- a/app/controllers/nu_core_files_controller.rb
+++ b/app/controllers/nu_core_files_controller.rb
@@ -32,7 +32,8 @@ class NuCoreFilesController < ApplicationController
   before_filter :can_edit_parent?, only: [:new]
 
   before_filter :can_read?, only: [:show] 
-  before_filter :can_edit?, only: [:edit, :update, :destroy] 
+  before_filter :can_edit?, only: [:edit, :update]
+  before_filter :is_depositor?, only: [:destroy] 
 
 
   rescue_from Exceptions::NoParentFoundError, with: :no_parent_rescue

--- a/lib/drs/controller_helpers/editable_objects.rb
+++ b/lib/drs/controller_helpers/editable_objects.rb
@@ -56,6 +56,16 @@ module Drs
         end
       end
 
+      def is_depositor? 
+        record = ActiveFedora::Base.find(params[:id], cast: true) 
+
+        if !current_user.nil? && current_user.nuid == record.depositor 
+          return true 
+        else
+          render_403 
+        end
+      end
+
       private
       
         def find_parent(hash) 

--- a/spec/controllers/nu_collections_controller_spec.rb
+++ b/spec/controllers/nu_collections_controller_spec.rb
@@ -209,6 +209,17 @@ describe NuCollectionsController do
       response.status.should == 403 
     end
 
+    it "403s for users who have edit permissions but are not the depositor" do 
+      # Give edit permissions to bo to prove a point
+      root.rightsMetadata.permissions({person: '000000002'}, 'edit') 
+      root.save! 
+
+      sign_in bo 
+
+      delete :destroy, { id: root.pid } 
+      response.status.should == 403 
+    end
+
     it "destroys root and its descendent collection" do
       sign_in bill
 

--- a/spec/controllers/nu_core_files_controller_spec.rb
+++ b/spec/controllers/nu_core_files_controller_spec.rb
@@ -86,7 +86,17 @@ describe NuCoreFilesController do
       response.status.should == 403 
     end
 
-    it "successfully removes the item for users with edit permissions" do 
+    it "403s for users who aren't the depositor but have edit permissions" do 
+      file.rightsMetadata.permissions({person: '000000002'}, 'edit') 
+      file.save!
+
+      sign_in bo
+
+      delete :destroy, { id: file.pid } 
+      response.status.should == 403
+    end 
+
+    it "successfully removes the item for the depositor" do 
       sign_in bill 
       file_pid = file.pid
 


### PR DESCRIPTION
Only depositors should be able to delete core records/collections.  Communities already can't be deleted by normal users and compilations still assume that they are 100% private, which I think we discussed and decided was alright at some point.  
